### PR TITLE
fix(deploy): enabled whitenoise for serving staticfiles without NGINX in Railway

### DIFF
--- a/bennu_official/settings.py
+++ b/bennu_official/settings.py
@@ -23,7 +23,7 @@ INSTALLED_APPS = [
 # https://whitenoise.readthedocs.io/en/stable/django.html#enable-whitenoise
 MIDDLEWARE = [
     'django.middleware.security.SecurityMiddleware',
-    # 'whitenoise.middleware.WhiteNoiseMiddleware',
+    'whitenoise.middleware.WhiteNoiseMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',


### PR DESCRIPTION
## Issue link
relates: #209 

## What does this PR do?
- commented out whitenoise middleware in settings.py

## (Optional) Additional Contexts or Justifications
With the changes of #214, we have successfully deployed app on Railway but still staticfile is not served, even though any other operations related to database had been completed. (such as migrate/loaddata)
Since we does not have NGINX proxy server on Railway environment whereas code base expected proxy server to serve staticfiles.