### PR TITLE
fix(ci): removed pack-cli commands for image push.

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -9,10 +9,6 @@ on:
 
 env:
   IMAGE_NAME: ghcr.io/${{ github.repository }}
-  # MYSQL_HOSTNAME: 127.0.0.1
-  MYSQL_ROOT_PASSWORD: root
-  MYSQL_DATABASE: bennu
-  MYSQL_USER: root
 
 jobs:
   build:

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -22,14 +22,10 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
         # https://github.com/docker/login-action#github-container-registry
 
-      - name: Install pack
-        uses: buildpacks/github-actions/setup-pack@v5.8.4
-        # https://github.com/buildpacks/github-actions#setup-pack-cli-action
-
-      - name: Publish packages
-        run: |
-          pack build ghcr.io/hwakabh/bennu-official:latest \
-            --builder gcr.io/buildpacks/builder:latest \
-            --path . \
-            --env "$(cat .python-version)" \
-            --publish
+      - name: Publish packages by Nixpacks
+        uses: iloveitaly/github-action-nixpacks@main
+        with:
+          push: true
+          tags: |
+            ${{ env.IMAGE_NAME }}:local
+          # https://github.com/iloveitaly/github-action-nixpacks


### PR DESCRIPTION
## Issue link
relates: #216 

## What does this PR do?
- removed `pack` commands from Publish CI
- removed unused environmental variables from Build CI

## (Optional) Additional Contexts or Justifications
For validation of this changes for Publish CI requires to merge this PR first.