### PR TITLE
feat(ci): added envkeeper scheduled jobs.

### DIFF
--- a/.github/workflows/scheduled_environment_cleanup.yaml
+++ b/.github/workflows/scheduled_environment_cleanup.yaml
@@ -1,0 +1,16 @@
+name: Purge staled environment
+
+on:
+  schedule:
+    # Runs on 19:00 JST every day, note that cron syntax applied as UTC
+    - cron: '0 10 * * *'
+  workflow_dispatch:
+
+jobs:
+  cleanup-env:
+    steps:
+      - name: Clean up Environments
+        uses: hwakabh/envkeeper@0.3.0
+        with:
+          token: ${{ secrets.PAT_CLEANUP }}
+          repo: ${{ github.repository }}

--- a/.github/workflows/scheduled_image_cleanup.yaml
+++ b/.github/workflows/scheduled_image_cleanup.yaml
@@ -19,4 +19,4 @@ jobs:
           # Keep 1 image within 1 days ago
           keep-at-least: 1
           account-type: personal
-          token: ${{ secrets.PAT_PACKAGE_CLEANUP }}
+          token: ${{ secrets.PAT_CLEANUP }}


### PR DESCRIPTION
## Issue link
relates: #217 

## What does this PR do?
- added jobs to clean up environment with `hwakabh/envkeeper`
- updated repository secret name from `PAT_PACKAGE_CLEANUP` to `PAT_CLEANUP`, since all scheduled workflows will be used same one

## (Optional) Additional Contexts or Justifications
- validations of scheduled workflow will need for awaiting at least a day to be invoked.