### PR TITLE
fix(ci): added runs-on fields for envkeeper.

### DIFF
--- a/.github/workflows/scheduled_environment_cleanup.yaml
+++ b/.github/workflows/scheduled_environment_cleanup.yaml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   cleanup-env:
+    runs-on: ubuntu-24.04
     steps:
       - name: Clean up Environments
         uses: hwakabh/envkeeper@0.3.0


### PR DESCRIPTION
## Issue link
relates: #217 

## What does this PR do?
SSIA, for fixing the error below in [the run](https://github.com/hwakabh/bennu-official.page/actions/runs/13019850721/workflow):
```shell
Invalid workflow file: .github/workflows/scheduled_environment_cleanup.yaml#L11
The workflow is not valid. .github/workflows/scheduled_environment_cleanup.yaml (Line: 11, Col: 5): Required property is missing: runs-on
```

## (Optional) Additional Contexts or Justifications
N/A