### PR TITLE
fix(ci): added proper versions of envkeeper.

### DIFF
--- a/.github/workflows/scheduled_environment_cleanup.yaml
+++ b/.github/workflows/scheduled_environment_cleanup.yaml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Clean up Environments
-        uses: hwakabh/envkeeper@0.3.0
+        uses: hwakabh/envkeeper@v0.3.0
         with:
           token: ${{ secrets.PAT_CLEANUP }}
           repo: ${{ github.repository }}


### PR DESCRIPTION
## Issue link
relates: #217 

## What does this PR do?
- fixed version tag of `hwakabh/envkeeper` from `0.3.0` to `v0.3.0` properly

## (Optional) Additional Contexts or Justifications
N/A