### PR TITLE
deploy: fixed R10 error on Heroku

### DIFF
--- a/manifests/configs/gunicorn.conf.py
+++ b/manifests/configs/gunicorn.conf.py
@@ -8,7 +8,8 @@ wsgi_app = 'bennu_official.wsgi'
 raw_env = []
 
 # Server Socket
-bind = '0.0.0.0:8000'
+import os
+bind = '0.0.0.0:' + os.environ.get('PORT', '8000')
 
 # Worker Processes
 worker_class = 'gthread'


### PR DESCRIPTION
## Issue link
SSIA
ref: https://help.heroku.com/W5ETWBQB/why-is-my-app-crashing-with-an-r10-error

For fixing the following error on application booting:
```log
2025-04-10T13:34:12.354835+00:00 heroku[web.1]: Error R10 (Boot timeout) -> Web process failed to bind to $PORT within 60 seconds of launch
2025-04-10T13:34:12.369753+00:00 heroku[web.1]: Stopping process with SIGKILL
2025-04-10T13:34:12.426538+00:00 heroku[web.1]: Process exited with status 137
2025-04-10T13:34:12.450475+00:00 heroku[web.1]: State changed from starting to crashed
```

## What does this PR do?
SSIA, made dynamic of port number to listen, once after fetching `PORT` from runtime.

## (Optional) Additional Contexts or Justifications
N/A